### PR TITLE
Fix a warning

### DIFF
--- a/src/BlurDetection.cpp
+++ b/src/BlurDetection.cpp
@@ -93,6 +93,9 @@ bool prl::isBlurred(const cv::Mat& src, prl::BlurDetectionAlgo algo)
             return TENG_Algo(src, 5);
         case BlurDetectionAlgo::GLVN:
             return GLVN_Algo(src);
+        default:
+        break;
     }
+    return false;
 }
 


### PR DESCRIPTION
````
[ 12%] Building CXX object CMakeFiles/prlib.dir/src/BlurDetection.cpp.o
$HOME/Devel/MATHS/PRLib/src/BlurDetection.cpp: In function ‘bool prl::isBlurred(const cv::Mat&, prl::BlurDetectionAlgo)’:
$HOME/Devel/MATHS/PRLib/src/BlurDetection.cpp:97:1: warning: control reaches end of non-void function [-Wreturn-type]
   97 | }

````

The warning is caused by nothing is returned once the right algo is found. I'd suggest to return false when no algo is found, thus a false value returned will help top detect a problem. And the warning will automaticaly vanish at build time, what cannot be bad :-)

Feel free to accept (or not) this little change under MIT license, (or whatever you need).

Thanks again for sharing your code !

With best regards,
Eric Bachard