### PR TITLE
Change method pixOrientDwa -> pixOrient

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,8 @@ The main aim of the library - prepare image for recogntion. Image processing can
 ```
     make
 ```    
+
+*Build tested*
+
+- Opencv: 4.7.0
+- Leptonica: 1.82.0-3

--- a/src/Deskew.cpp
+++ b/src/Deskew.cpp
@@ -71,7 +71,7 @@ double FindOrientation(const cv::Mat& input)
     {
         l_float32 fUpConf;
         l_float32 fLeftConf;
-        if (pixOrientDetectDwa(pix, &fUpConf, &fLeftConf, 0, 0) != 0)
+        if (pixOrientDetect(pix, &fUpConf, &fLeftConf, 0, 0) != 0)
         {
             if (pix)
             {


### PR DESCRIPTION
# What ?

Change leptonica function from pixOrientDwa -> pixOrient

# Why?

Encountered error when building PRLib using libleptonica (1.82.03 )

```
/home/kenny/downloads/PRLib/src/Deskew.cpp:74:13: error: ‘pixOrientDetectDwa’ was not declared in this scope; did you mean ‘pixOrientDetect’?
   74 |         if (pixOrientDetectDwa(pix, &fUpConf, &fLeftConf, 0, 0) != 0)
      |             ^~~~~~~~~~~~~~~~~~
      |             pixOrientDetect
```

